### PR TITLE
動詞抜けを修正

### DIFF
--- a/translation-ja/releases.md
+++ b/translation-ja/releases.md
@@ -87,7 +87,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
 デフォルトのLaravelアプリケーション構造には５つのサービスプロバイダを持っていましたが、Laravel11では１つの`AppServiceProvider`しかありません。以前のサービスプロバイダの機能は、`bootstrap/app.php`に組み込まれたり、フレームワークが自動的に処理したり、アプリケーションの`AppServiceProvider`へ配置されたりしました。
 
-例えば、イベントディスカバリはデフォルトで有効になり、イベントとそのリスナを手作業で登録する必要をほぼ無くしました。しかし、イベントを手作業で登録する必要がある場合は、`AppServiceProvider`に登録するだけです。同様に、以前 `AuthServiceProvider`で登録していた、ルートモデル結合や認証ゲートも、`AppServiceProvider`できます。
+例えば、イベントディスカバリはデフォルトで有効になり、イベントとそのリスナを手作業で登録する必要をほぼ無くしました。しかし、イベントを手作業で登録する必要がある場合は、`AppServiceProvider`に登録するだけです。同様に、以前 `AuthServiceProvider`で登録していた、ルートモデル結合や認証ゲートも、`AppServiceProvider`に登録できます。
 
 <a name="opt-in-routing"></a>
 #### オプトインAPIとブロードキャストルーティング


### PR DESCRIPTION
日本語に違和感を感じたため、原文を再度確認して修正させていただきました。ご確認いただけますと幸いです。

以下原文

> For example, event discovery is now enabled by default, largely eliminating the need for manual registration of events and their listeners. However, if you do need to manually register events, you may simply do so in the `AppServiceProvider`. Similarly, route model bindings or authorization gates you may have previously registered in the `AuthServiceProvider` may also be registered in the `AppServiceProvider`.
