### PR TITLE
Laravel Sailページへのリンク先URLの誤字を修正

### DIFF
--- a/translation-ja/artisan.md
+++ b/translation-ja/artisan.md
@@ -42,7 +42,7 @@ php artisan help migrate
 <a name="laravel-sail"></a>
 #### Laravel Sail
 
-ローカル開発環境として[Laravel Sail](/docs/{{version}}/sale)を使用している場合は、必ず`sail`コマンドラインを使用してArtisanコマンドを呼び出してください。Sailは、アプリケーションのDockerコンテナ内でArtisanコマンドを実行します。
+ローカル開発環境として[Laravel Sail](/docs/{{version}}/sail)を使用している場合は、必ず`sail`コマンドラインを使用してArtisanコマンドを呼び出してください。Sailは、アプリケーションのDockerコンテナ内でArtisanコマンドを実行します。
 
 ```shell
 ./vendor/bin/sail artisan list

--- a/translation-ja/dusk.md
+++ b/translation-ja/dusk.md
@@ -76,7 +76,7 @@ php artisan dusk:install
 次に、アプリケーションの`.env`ファイルに`APP_URL`環境変数を設定します。この値は、ブラウザでアプリケーションにアクセスするために使用するURLと一致させる必要があります。
 
 > [!NOTE]
-> [Laravel Sail](/docs/{{version}}/sale)を使用してローカル開発環境を管理している場合は、[Duskテストの設定と実行](/docs/{{version}}/sail#laravel-dusk)に関するSailのドキュメントも参照してください。
+> [Laravel Sail](/docs/{{version}}/sail)を使用してローカル開発環境を管理している場合は、[Duskテストの設定と実行](/docs/{{version}}/sail#laravel-dusk)に関するSailのドキュメントも参照してください。
 
 <a name="managing-chromedriver-installations"></a>
 ### Chromeドライバインストールの管理
@@ -288,7 +288,7 @@ php artisan dusk --group=foo
 ```
 
 > [!NOTE]
-> [Laravel Sail](/docs/{{version}}/sale)を使用してローカル開発環境を管理している場合は、[Duskテストの設定と実行](/docs/{{version}}/sail#laravel-dusk)に関するSailのドキュメントを参照してください。
+> [Laravel Sail](/docs/{{version}}/sail)を使用してローカル開発環境を管理している場合は、[Duskテストの設定と実行](/docs/{{version}}/sail#laravel-dusk)に関するSailのドキュメントを参照してください。
 
 <a name="manually-starting-chromedriver"></a>
 #### ChromeDriverの手作業起動

--- a/translation-ja/mail.md
+++ b/translation-ja/mail.md
@@ -1259,7 +1259,7 @@ class ExampleTest extends TestCase
 
 もしくは、[HELO](https://usehelo.com)や[Mailtrap](https://mailtrap.io)などのサービスと`smtp`ドライバを使用して、メールメッセージを「ダミー」メールボックスに送信可能です。本当の電子メールクライアントでそれらを表示できます。このアプローチには、Mailtrapのメッセージビューアで最終的な電子メールを実際に調べられるという利点があります。
 
-[Laravel Sail](/docs/{{version}}/sale)を使用している場合は、[Mailpit](https://github.com/axllent/mailpit)を使用してメッセージをプレビューできます。Sailの実行中は、`http://localhost:8025`でMailpitインターフェイスにアクセスできます。
+[Laravel Sail](/docs/{{version}}/sail)を使用している場合は、[Mailpit](https://github.com/axllent/mailpit)を使用してメッセージをプレビューできます。Sailの実行中は、`http://localhost:8025`でMailpitインターフェイスにアクセスできます。
 
 <a name="using-a-global-to-address"></a>
 #### グローバルな`to`アドレスの使用

--- a/translation-ja/redis.md
+++ b/translation-ja/redis.md
@@ -15,7 +15,7 @@
 
 [Redis](https://redis.io)はオープンソースの高度なキー／値保存域です。キーには[文字列](https://redis.io/docs/data-types/strings/)、[ハッシュ](https://redis.io/docs/data-types/hashes/)、[リスト](https://redis.io/docs/data-types/lists/)、[セット](https://redis.io/docs/data-types/sets/)、[ソート済みセット](https://redis.io/docs/data-types/sorted-sets/)を含むことができるため、データ構造サーバと呼ばれることが多いです。
 
-LaravelでRedisを使い始める前に、PECLにより[PhpRedis](https://github.com/phpredis/phpredis)PHP拡張機能をインストールして使用することを推奨します。この拡張機能は、「ユーザーフレンドリー」なPHPパッケージに比べてインストールは複雑ですが、Redisを多用するアプリケーションのパフォーマンスが向上する可能性があります。[Laravel Sail](/docs/{{version}}/sale)を使用している場合、この拡張機能はアプリケーションのDockerコンテナにはじめからインストールしてあります。
+LaravelでRedisを使い始める前に、PECLにより[PhpRedis](https://github.com/phpredis/phpredis)PHP拡張機能をインストールして使用することを推奨します。この拡張機能は、「ユーザーフレンドリー」なPHPパッケージに比べてインストールは複雑ですが、Redisを多用するアプリケーションのパフォーマンスが向上する可能性があります。[Laravel Sail](/docs/{{version}}/sail)を使用している場合、この拡張機能はアプリケーションのDockerコンテナにはじめからインストールしてあります。
 
 PhpRedis拡張機能をインストールできない場合は、Composerを介して`predis/predis`パッケージをインストールしてください。PredisはすべてPHPで記述されたRedisクライアントであり、追加の拡張機能は必要ありません。
 

--- a/translation-ja/valet.md
+++ b/translation-ja/valet.md
@@ -27,7 +27,7 @@
 
 [Laravel Valet](https://github.com/laravel/valet)（バレット：従者）は、macOSミニマリスト向けのLaravel開発環境です。Larave lValetは、マシンの起動時に常にバックグラウンドで[Nginx](https://www.nginx.com/)を実行するようにMacを設定します。次に、[DnsMasq](https://en.wikipedia.org/wiki/Dnsmasq)を使用して、Valetは`*.test`ドメイン上のすべてのリクエストをプロキシし、ローカルマシンにインストールしているサイトへ転送します。
 
-言い換えれば、Valetは、約７MBのRAMを使用する非常に高速なLaravel開発環境です。Valetは、[Sail](/docs/{{version}}/sale)や[Homestead](/docs/{{version}}/homestead)の完全な代替ではありませんが、極端に速度を好むとかRAMの量が限られているマシンで作業しているなど、柔軟な開発環境の基本が必要な場合は優れた代替手段になるでしょう。
+言い換えれば、Valetは、約７MBのRAMを使用する非常に高速なLaravel開発環境です。Valetは、[Sail](/docs/{{version}}/sail)や[Homestead](/docs/{{version}}/homestead)の完全な代替ではありませんが、極端に速度を好むとかRAMの量が限られているマシンで作業しているなど、柔軟な開発環境の基本が必要な場合は優れた代替手段になるでしょう。
 
 Valetは以下をサポートしていますが、これらに限定されません。
 


### PR DESCRIPTION
日本語版のメンテナンスをいつもありがとうございます。利用させていただいております。

複数ページにてLaravel Sailページへのリンク先URL部分の誤字を見つけましたので修正いたしました。
ご確認をよろしくお願いします。
（他の箇所にて同様の誤字がないことは念の為確認済みです。）

- 対象ページ
    - Artisanコンソール
    - Dusk
    - メール
    - Redis
    - Valet