### PR TITLE
Markdownが認識できないリンクを修正

### DIFF
--- a/translation-ja/validation.md
+++ b/translation-ja/validation.md
@@ -2072,7 +2072,7 @@ The arguments [accepted by the `DateTimeZone::listIdentifiers` method](https://w
 <a name="error-message-indexes-and-positions"></a>
 ### エラーメッセージインデックスとポジション
 
-配列のバリデーションを行うとき、失敗した特定項目のインデックスや位置をアプリケーションのエラーメッセージから参照したいことがあります。これを行うには、[カスタムバリデーションメッセージ] (#manual-customizing-the-error-messages)へ、`:index`（０始点）と`:position`（１始点）のプレースホルダを使ってください。
+配列のバリデーションを行うとき、失敗した特定項目のインデックスや位置をアプリケーションのエラーメッセージから参照したいことがあります。これを行うには、[カスタムバリデーションメッセージ](#manual-customizing-the-error-messages)へ、`:index`（０始点）と`:position`（１始点）のプレースホルダを使ってください。
 
     use Illuminate\Support\Facades\Validator;
 


### PR DESCRIPTION
「基礎 - バリデーション」でMarkdownパーサがリンクを認識できていないのを修正しました。

どういった環境でビルドされているのかわからないので手元で再現や修正確認を行えていないのですが、正しく認識できている `8.x` のドキュメントのコードを確認したところ、半角スペースの混入が原因ではないかと思います。

![バリデーション](https://github.com/user-attachments/assets/3b138839-1456-41fd-a4ad-4c2eb8f9ac2a)
